### PR TITLE
fix some misprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ wget https://github.com/bkimminich/juice-shop/releases/download/v7.5.1/juice-sho
 
 tar -zxvf juice-shop-7.5.1_node10_linux_x64.tgz
 
-cd juice-shop-7.5.1/
+cd juice-shop_7.5.1
 
-nmp start
+npm start
 
 Look at http://IP_from_ipconfig:3000/
 
@@ -193,8 +193,6 @@ Authmatrix
 https://github.com/danielmiessler/SecLists
 
 https://github.com/fuzzdb-project/fuzzdb
-
-https://github.com/Bo0oM/fuzz.txt
 
 # What you are going to read after:
 


### PR DESCRIPTION
cd juice-shop-7.5.1/ -> cd juice-shop_7.5.1
nmp start -> npm start
<img width="1113" alt="screenshot_proof" src="https://user-images.githubusercontent.com/16885366/46312834-ede5df00-c5ce-11e8-86cc-9faa93263cab.png">

delete https://github.com/Bo0oM/fuzz.txt -> the link does not work, response  404